### PR TITLE
Initial skeleton for AD DS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # ADDSSimulator
-Cisco packet tracer-like application for simulating AD DS architecture
+
+Minimal Node.js proof-of-concept for a Microsoft Active Directory Domain Services simulator. It models three core infrastructure components:
+
+- **Domain Controller** – stores users and authenticates credentials.
+- **DNS Server** – resolves host names to IP addresses.
+- **DHCP Server** – leases IP addresses to clients.
+
+A simple `Simulator` class wires these services together and exposes methods for creating users and clients. The accompanying test demonstrates a client receiving an IP address via DHCP, resolving a DNS record, and authenticating against the domain controller.
+
+## Development
+
+```bash
+npm test
+```
+
+Running the test executes `test.js`, which exercises the simulator and prints **All tests passed** on success.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "addssimulator",
+  "version": "1.0.0",
+  "description": "Cisco packet tracer-like application for simulating AD DS architecture",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,24 @@
+class Client {
+  constructor(name, dhcp, dns, domainController) {
+    this.name = name;
+    this.dhcp = dhcp;
+    this.dns = dns;
+    this.domainController = domainController;
+    this.ip = null;
+  }
+
+  boot() {
+    const leaseNum = this.dhcp.leaseAddress(this.name);
+    this.ip = require('./dhcpServer').numberToIp(leaseNum);
+  }
+
+  resolve(hostname) {
+    return this.dns.resolve(hostname);
+  }
+
+  logon(username, password) {
+    return this.domainController.authenticate(username, password);
+  }
+}
+
+module.exports = Client;

--- a/src/dhcpServer.js
+++ b/src/dhcpServer.js
@@ -1,0 +1,35 @@
+function ipToNumber(ip) {
+  return ip.split('.').reduce((acc, oct) => (acc << 8) + Number(oct), 0);
+}
+
+function numberToIp(num) {
+  return [24, 16, 8, 0].map(shift => (num >> shift) & 255).join('.');
+}
+
+class DhcpServer {
+  constructor(startIp, endIp) {
+    this.start = ipToNumber(startIp);
+    this.end = ipToNumber(endIp);
+    this.leases = new Map(); // client -> ip number
+  }
+
+  leaseAddress(clientId) {
+    if (this.leases.has(clientId)) {
+      return this.leases.get(clientId);
+    }
+    for (let ipNum = this.start; ipNum <= this.end; ipNum++) {
+      if (![...this.leases.values()].includes(ipNum)) {
+        this.leases.set(clientId, ipNum);
+        return ipNum;
+      }
+    }
+    throw new Error('No available IP addresses');
+  }
+
+  getLease(clientId) {
+    const num = this.leases.get(clientId);
+    return num ? numberToIp(num) : null;
+  }
+}
+
+module.exports = { DhcpServer, ipToNumber, numberToIp };

--- a/src/dnsServer.js
+++ b/src/dnsServer.js
@@ -1,0 +1,15 @@
+class DnsServer {
+  constructor() {
+    this.records = new Map();
+  }
+
+  addRecord(hostname, ip) {
+    this.records.set(hostname, ip);
+  }
+
+  resolve(hostname) {
+    return this.records.get(hostname) || null;
+  }
+}
+
+module.exports = DnsServer;

--- a/src/domainController.js
+++ b/src/domainController.js
@@ -1,0 +1,20 @@
+class DomainController {
+  constructor(domainName) {
+    this.domainName = domainName;
+    this.users = new Map();
+  }
+
+  addUser(username, password) {
+    if (this.users.has(username)) {
+      throw new Error(`User ${username} already exists`);
+    }
+    this.users.set(username, { password });
+  }
+
+  authenticate(username, password) {
+    const user = this.users.get(username);
+    return Boolean(user && user.password === password);
+  }
+}
+
+module.exports = DomainController;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,26 @@
+const DomainController = require('./domainController');
+const DnsServer = require('./dnsServer');
+const { DhcpServer } = require('./dhcpServer');
+const Client = require('./client');
+
+class Simulator {
+  constructor() {
+    this.dc = new DomainController('contoso.local');
+    this.dns = new DnsServer();
+    this.dhcp = new DhcpServer('192.168.1.10', '192.168.1.100');
+  }
+
+  addUser(username, password) {
+    this.dc.addUser(username, password);
+  }
+
+  addHostRecord(hostname, ip) {
+    this.dns.addRecord(hostname, ip);
+  }
+
+  createClient(name) {
+    return new Client(name, this.dhcp, this.dns, this.dc);
+  }
+}
+
+module.exports = Simulator;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const Simulator = require('./src/index');
+
+const sim = new Simulator();
+sim.addUser('alice', 'password123');
+sim.addHostRecord('dc1.contoso.local', '192.168.1.10');
+
+const client = sim.createClient('CLIENT1');
+client.boot();
+
+assert.strictEqual(client.ip, '192.168.1.10');
+assert.strictEqual(client.resolve('dc1.contoso.local'), '192.168.1.10');
+assert.strictEqual(client.logon('alice', 'password123'), true);
+assert.strictEqual(client.logon('alice', 'wrong'), false);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- scaffold minimal Node.js proof-of-concept for Active Directory Domain Services simulation
- add domain controller, DNS, and DHCP service classes with a simulator wrapper
- provide simple test verifying DHCP lease, DNS resolution, and user authentication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a3c53d58832cbc52a7ed0676d720